### PR TITLE
Update README with all parameters and add liveness delay parameter

### DIFF
--- a/charts/mq-advancedserver/README.md
+++ b/charts/mq-advancedserver/README.md
@@ -43,18 +43,24 @@ kubectl delete pvc -l release=foo
 The following table lists the configurable parameters of the `mq-advancedserver` chart and their default values.
 
 | Parameter                       | Description                                     | Default                                                    |
-| ----------------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
-| `license`                    | Set to `accept` to accept the terms of the IBM license  | `not accepted`                                                      |
-| `image.name`                    | Image name                                      | `nil`                                                      |
+| ------------------------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| `license`                       | Set to `accept` to accept the terms of the IBM license  | `not accepted`                                     |
+| `image.repository`              | Image full name including repository            | `nil`                                                      |
 | `image.tag`                     | Image tag                                       | `nil`                                                      |
 | `image.pullPolicy`              | Image pull policy                               | `IfNotPresent`                                             |
 | `image.pullSecret`              | Image pull secret, if you are using a private Docker registry | `nil`                                        |
 | `data.persistence.enabled`      | Use a PersistentVolume to persist MQ data (under `/var/mqm`)  | `true`                                       |
-| `data.persistence.storageClass` | Storage class of backing Persistent Volume                    | `nil`                                        |
+| `data.persistence.storageClass` | Storage class of backing Persistent Volume      | `nil`                                                      |
 | `data.persistence.size`         | Size of data volume                             | `2Gi`                                                      |
 | `service.name`                  | Name of the Kubernetes service to create        | `qmgr`                                                     |
 | `service.type`                  | Kubernetes service type exposing ports, e.g. `NodePort`       | `ClusterIP`                                  |
-| `queueManager.name`                  | MQ Queue Manager name       | Helm release name                                  |
+| `resources.limits.cpu`          | Kubernetes CPU limit for the Queue Manager container | `1`                                                   |
+| `resources.limits.memory`       | Kubernetes memory limit for the Queue Manager container | `1Gi`                                              |
+| `resources.requests.cpu`        | Kubernetes CPU request for the Queue Manager container | `1`                                                 |
+| `resources.requests.memory`     | Kubernetes memory request for the Queue Manager container | `1Gi`                                            |
+| `queueManager.name`             | MQ Queue Manager name       | Helm release name                                                              |
+| `nameOverride`                  | Set to partially override the resource names used in this chart | `nil`                                      |
+| `livenessDelay`                 | Raises the time out before Kubernetes checks for Queue Manager's health. Useful for slower systems that take longer to start the Queue Manager. | 60 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/mq-advancedserver/templates/stateful-set.yaml
+++ b/charts/mq-advancedserver/templates/stateful-set.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: qmgr
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }} 
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: 1414
           env:
@@ -56,9 +56,9 @@ spec:
           # Set liveness probe to determine if the queue manager is running
           livenessProbe:
             exec:
-              command: 
+              command:
               - chkmqhealthy
-            initialDelaySeconds: 60
+            initialDelaySeconds: {{ .Values.livenessDelay }}
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 1
@@ -92,5 +92,5 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: {{ .Values.data.persistence.size | quote }} 
+          storage: {{ .Values.data.persistence.size | quote }}
   {{- end }}

--- a/charts/mq-advancedserver/values.yaml
+++ b/charts/mq-advancedserver/values.yaml
@@ -16,10 +16,10 @@
 license: "not accepted"
 image:
   # repository is the container repository to use, which must contain IBM MQ Advanced
-  repository: 
+  repository:
   # tag is the tag to use for the container repository
   tag:
-  # pullSecret is the secret to use when pulling the image from a private registry 
+  # pullSecret is the secret to use when pulling the image from a private registry
   pullSecret:
   # pullPolicy is either IfNotPresent or Always (https://kubernetes.io/docs/concepts/containers/images/)
   pullPolicy: IfNotPresent
@@ -49,3 +49,5 @@ queueManager:
   name:
 # nameOverride can be set to partially override the name of the resources created by this chart
 nameOverride:
+# livenessDelay should be raised if your system cannot start the Queue Manager in 60 seconds
+livenessDelay: 60

--- a/charts/mq-devserver/README.md
+++ b/charts/mq-devserver/README.md
@@ -54,6 +54,10 @@ The following table lists the configurable parameters of the `mq-advancedserver`
 | `data.persistence.size`          | Size of data volume                             | `2Gi`                                                      |
 | `service.name`                   | Name of the Kubernetes service to create        | `qmgr`                                                     |
 | `service.type`                   | Kubernetes service type exposing ports, e.g. `NodePort`       | `ClusterIP`                                  |
+| `resources.limits.cpu`          | Kubernetes CPU limit for the Queue Manager container | `500m`                                                   |
+| `resources.limits.memory`       | Kubernetes memory limit for the Queue Manager container | `512Mi`                                              |
+| `resources.requests.cpu`        | Kubernetes CPU request for the Queue Manager container | `500m`                                                 |
+| `resources.requests.memory`     | Kubernetes memory request for the Queue Manager container | `512Mi`                                            |
 | `queueManager.name`              | MQ Queue Manager name                           | Helm release name                                          |
 | `queueManager.dev.adminPassword` | Developer defaults - administrator password     | Random generated string.  See the notes that appear when you install for how to retrieve this.                            |
 | `queueManager.dev.appPassword`   | Developer defaults - app password   | `nil` (no password required to connect an MQ client)                   |

--- a/charts/mq-devserver/README.md
+++ b/charts/mq-devserver/README.md
@@ -37,26 +37,27 @@ The command removes all the Kubernetes components associated with the chart, exc
 
 ```bash
 kubectl delete pvc -l release=foo
-``` 
+```
 
 ## Configuration
 The following table lists the configurable parameters of the `mq-advancedserver` chart and their default values.
 
-| Parameter                       | Description                                     | Default                                                    |
-| ----------------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
-| `license`                        | Set to `accept` to accept the terms of the IBM license  | `not accepted`                                    |
-| `image.name`                     | Image name                                      | `ibmcom/mq`                                               |
-| `image.tag`                      | Image tag                                       | `9`                                                       |
-| `image.pullPolicy`               | Image pull policy                               | `IfNotPresent`                                            |
-| `image.pullSecret`               | Image pull secret, if you are using a private Docker registry | `nil`                                       |
-| `data.persistence.enabled`       | Use a PersistentVolume to persist MQ data (under `/var/mqm`)  | `true`                                      |
-| `data.persistence.storageClass`  | Storage class of backing Persistent Volume                    | `nil`                                       |
-| `data.persistence.size`          | Size of data volume                             | `2Gi`                                                     |
-| `service.name`                   | Name of the Kubernetes service to create        | `qmgr`                                                    |
-| `service.type`                   | Kubernetes service type exposing ports, e.g. `NodePort`       | `ClusterIP`                                 |
-| `queueManager.name`              | MQ Queue Manager name                           | Helm release name                                         |
+| Parameter                        | Description                                     | Default                                                    |
+| -------------------------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| `license`                        | Set to `accept` to accept the terms of the IBM license  | `not accepted`                                     |
+| `image.repository`               | Image full name including repository            | `ibmcom/mq`                                                |
+| `image.tag`                      | Image tag                                       | `9`                                                        |
+| `image.pullPolicy`               | Image pull policy                               | `IfNotPresent`                                             |
+| `image.pullSecret`               | Image pull secret, if you are using a private Docker registry | `nil`                                        |
+| `data.persistence.enabled`       | Use a PersistentVolume to persist MQ data (under `/var/mqm`)  | `true`                                       |
+| `data.persistence.storageClass`  | Storage class of backing Persistent Volume                    | `nil`                                        |
+| `data.persistence.size`          | Size of data volume                             | `2Gi`                                                      |
+| `service.name`                   | Name of the Kubernetes service to create        | `qmgr`                                                     |
+| `service.type`                   | Kubernetes service type exposing ports, e.g. `NodePort`       | `ClusterIP`                                  |
+| `queueManager.name`              | MQ Queue Manager name                           | Helm release name                                          |
 | `queueManager.dev.adminPassword` | Developer defaults - administrator password     | Random generated string.  See the notes that appear when you install for how to retrieve this.                            |
-| `queueManager.dev.appPassword`   | Developer defaults - app password   | `nil` (no password required to connect an MQ client) |
+| `queueManager.dev.appPassword`   | Developer defaults - app password   | `nil` (no password required to connect an MQ client)                   |
+| `nameOverride`                   | Set to partially override the resource names used in this chart | `nil`                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 


### PR DESCRIPTION
* livenessDelay parameter is used to raise the delay before we start checking the Queue Manager's health. This is useful for systems where the container startup (including Queue Manager create & start) takes longer than the default 60 seconds.