### PR TITLE
add backwards compatability for crtmqdir and JSON loggin

### DIFF
--- a/test/docker/docker_api_test.go
+++ b/test/docker/docker_api_test.go
@@ -476,8 +476,8 @@ func TestErrorLogRotation(t *testing.T) {
 	for {
 		execContainer(t, cli, id, "fred", []string{"bash", "-c", "/opt/mqm/samp/bin/amqsput FAKE"})
 
-		_, derpaderp := execContainer(t, cli, id, "mqm", []string{"bash", "-c", "wc -c < " + filepath.Join(dir, "AMQERR02.json")})
-		amqerr02size, _ := strconv.Atoi(derpaderp)
+		_, atoiStr := execContainer(t, cli, id, "mqm", []string{"bash", "-c", "wc -c < " + filepath.Join(dir, "AMQERR02.json")})
+		amqerr02size, _ := strconv.Atoi(atoiStr)
 
 		if amqerr02size > 0 {
 			// We've done enough to cause log rotation


### PR DESCRIPTION
tested with 9.0.3 and 9.0.5

Resolves issue #53 