### PR TITLE
update travis build stages to remove duplicate build and label

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,22 +27,26 @@ cache:
   directories:
     - downloads
 
-env:
-  - BASE_IMAGE=ubuntu:16.04
-  - BASE_IMAGE=centos:latest
-
 jobs:
   include:
-    - if: type IN (pull_request)
-      env: DOCKER_DOWNGRADE="docker save -o images.tar mqadvanced-server-dev mq-dev-jms-test &&
-        sudo apt-get autoremove -y docker-ce &&
-        curl -fsSL \"https://apt.dockerproject.org/gpg\" | sudo apt-key add - &&
-        sudo apt-add-repository \"deb https://apt.dockerproject.org/repo ubuntu-$(lsb_release -cs) main\" &&
-        sudo apt-get update &&
-        sudo apt-get install docker-engine=1.12.6-0~ubuntu-$(lsb_release -cs) &&
-        docker load -q -i images.tar &&
-        export DOCKER_API_VERSION=\"1.24\""
-    - env: DOCKER_DOWNGRADE="echo nothing to be done"
+    - stage: build and test
+      env:
+        - BASE_IMAGE=ubuntu:16.04
+        - DOCKER_DOWNGRADE="echo nothing to be done"
+    - env:
+        - BASE_IMAGE=centos:latest
+        - DOCKER_DOWNGRADE="echo nothing to be done"
+    - if: type IN (pull_request) OR tag IS present
+      env: 
+        - BASE_IMAGE=ubuntu:16.04
+        - DOCKER_DOWNGRADE="docker save -o images.tar mqadvanced-server-dev mq-dev-jms-test &&
+          sudo apt-get autoremove -y docker-ce &&
+          curl -fsSL \"https://apt.dockerproject.org/gpg\" | sudo apt-key add - &&
+          sudo apt-add-repository \"deb https://apt.dockerproject.org/repo ubuntu-$(lsb_release -cs) main\" &&
+          sudo apt-get update &&
+          sudo apt-get install docker-engine=1.12.6-0~ubuntu-$(lsb_release -cs) &&
+          docker load -q -i images.tar &&
+          export DOCKER_API_VERSION=\"1.24\""
 
 before_install:
   - ./install-build-deps-ubuntu.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# © Copyright IBM Corporation 2018
+# © Copyright IBM Corporation 2018, 2019
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR fixes the following:
* We're currently running 4 jobs in our travis build when we only need to run 3.
* We don't label the build stage to detail what it is doing
* The docker downgrade test isn't running on tag/release builds