### PR TITLE
Revert MQSC error check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNext
 
 * Now runs using the "mqm" user instead of root.  See new [security doc](https://github.com/ibm-messaging/mq-container/blob/master/docs/security.md)
-* [New IGNSTATE parameter for runmqsc START and STOP commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.pro.doc/q132310_.htm#q132310___ignstateparm) - From MQ version 9.1.1.0, any MQSC scripts included in the image should make use of the `IGNSTATE(YES)` parameter on any `START` and `STOP` commands. This allows for consistency when executing scripts multiple times (e.g. when a container is restarted) 
+* [New IGNSTATE parameter for runmqsc START and STOP commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.pro.doc/q132310_.htm#q132310___ignstateparm) - From MQ version 9.1.1.0, any MQSC scripts included in the image can make use of the `IGNSTATE(YES)` parameter on any `START` and `STOP` commands, allowing for greater consistency when executing scripts multiple times (e.g. when a container is restarted) 
 * Termination log moved from `/dev/termination-log` to `/run/termination-log`, to make permissions easier to handle
 * Fixes for the following issues:
     * Brackets no longer appear in termination log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNext
 
 * Now runs using the "mqm" user instead of root.  See new [security doc](https://github.com/ibm-messaging/mq-container/blob/master/docs/security.md)
-* [New IGNSTATE parameter for runmqsc START and STOP commands](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.pro.doc/q132310_.htm#q132310___ignstateparm) - From MQ version 9.1.1.0, any MQSC scripts included in the image can make use of the `IGNSTATE(YES)` parameter on any `START` and `STOP` commands, allowing for greater consistency when executing scripts multiple times (e.g. when a container is restarted) 
+* New [IGNSTATE](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.pro.doc/q132310_.htm#q132310___ignstateparm) parameter used in default developer config
 * Termination log moved from `/dev/termination-log` to `/run/termination-log`, to make permissions easier to handle
 * Fixes for the following issues:
     * Brackets no longer appear in termination log

--- a/cmd/runmqserver/qmgr.go
+++ b/cmd/runmqserver/qmgr.go
@@ -120,7 +120,6 @@ func configureQueueManager() error {
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				log.Errorf("Error running MQSC file %v (%v):\n\t%v", file.Name(), err, strings.Replace(string(out), "\n", "\n\t", -1))
-				return err
 			}
 			// Print the runmqsc output, adding tab characters to make it more readable as part of the log
 			log.Printf("Output for \"runmqsc\" with %v:\n\t%v", abs, strings.Replace(string(out), "\n", "\n\t", -1))

--- a/test/docker/docker_api_test.go
+++ b/test/docker/docker_api_test.go
@@ -536,39 +536,39 @@ func TestMQSC(t *testing.T) {
 
 // TestInvalidMQSC creates a new image with an MQSC file containing invalid MQSC,
 // tries to start a container based on that image, and checks that container terminates
-func TestInvalidMQSC(t *testing.T) {
-	t.Parallel()
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	var files = []struct {
-		Name, Body string
-	}{
-		{"Dockerfile", fmt.Sprintf(`
-		FROM %v
-		USER root
-		RUN rm -f /etc/mqm/*.mqsc
-		ADD mqscTest.mqsc /etc/mqm/
-		RUN chmod 0660 /etc/mqm/mqscTest.mqsc
-		USER mqm`, imageName())},
-		{"mqscTest.mqsc", "DEFINE INVALIDLISTENER('TEST.LISTENER.TCP') TRPTYPE(TCP) PORT(1414) CONTROL(QMGR) REPLACE"},
-	}
-	tag := createImage(t, cli, files)
-	defer deleteImage(t, cli, tag)
+// func TestInvalidMQSC(t *testing.T) {
+// 	t.Parallel()
+// 	cli, err := client.NewEnvClient()
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	var files = []struct {
+// 		Name, Body string
+// 	}{
+// 		{"Dockerfile", fmt.Sprintf(`
+// 		FROM %v
+// 		USER root
+// 		RUN rm -f /etc/mqm/*.mqsc
+// 		ADD mqscTest.mqsc /etc/mqm/
+// 		RUN chmod 0660 /etc/mqm/mqscTest.mqsc
+// 		USER mqm`, imageName())},
+// 		{"mqscTest.mqsc", "DEFINE INVALIDLISTENER('TEST.LISTENER.TCP') TRPTYPE(TCP) PORT(1414) CONTROL(QMGR) REPLACE"},
+// 	}
+// 	tag := createImage(t, cli, files)
+// 	defer deleteImage(t, cli, tag)
 
-	containerConfig := container.Config{
-		Env:   []string{"LICENSE=accept", "MQ_QMGR_NAME=qm1"},
-		Image: tag,
-	}
-	id := runContainer(t, cli, &containerConfig)
-	defer cleanContainer(t, cli, id)
-	rc := waitForContainer(t, cli, id, 60*time.Second)
-	if rc != 1 {
-		t.Errorf("Expected rc=1, got rc=%v", rc)
-	}
-	expectTerminationMessage(t, cli, id)
-}
+// 	containerConfig := container.Config{
+// 		Env:   []string{"LICENSE=accept", "MQ_QMGR_NAME=qm1"},
+// 		Image: tag,
+// 	}
+// 	id := runContainer(t, cli, &containerConfig)
+// 	defer cleanContainer(t, cli, id)
+// 	rc := waitForContainer(t, cli, id, 60*time.Second)
+// 	if rc != 1 {
+// 		t.Errorf("Expected rc=1, got rc=%v", rc)
+// 	}
+// 	expectTerminationMessage(t, cli, id)
+// }
 
 // TestReadiness creates a new image with large amounts of MQSC in, to
 // ensure that the readiness check doesn't pass until configuration has finished.


### PR DESCRIPTION
#261 returns an error if an MQSC script cant be run. This reverts to just logging the error as the IGNSTATE parameter does not cover all required commands for consistency in rerunning MQSC