### PR TITLE
runmqserver: fix/improve verifySingleProcess

### DIFF
--- a/cmd/runmqserver/process.go
+++ b/cmd/runmqserver/process.go
@@ -43,9 +43,9 @@ func verifySingleProcess() error {
 // Verifies that there is only one instance running of the given program name.
 func verifyOnlyOne(programName string) (int, error) {
 	// #nosec G104
-	out, _, _ := command.Run("ps", "-e", "--format", "cmd")
+	out, _, _ := command.Run("pgrep", programName)
 	//if this goes wrong then assume we are the only one
-	numOfProg := strings.Count(out, programName)
+	numOfProg := strings.Count(out, "\n")
 	if numOfProg != 1 {
 		return numOfProg, fmt.Errorf("Expected there to be only 1 instance of %s but found %d", programName, numOfProg)
 	}


### PR DESCRIPTION
A couple of patches to improve the `runmqserver` check for being the only process.

### 1. cmd/runmqserver.verifySingleProcess: optimize
    
Instead of using `ps`, which reads three `/proc` files per each process
(`stat`, `status`, and `cmdline`), use `pgrep` which only reads cmdline.
    
Also, `pgrep` output is simpler -- it only lists PIDs, one per line,
so to find out the number of processes we just need to count newlines.

### 2. cmd/runmqserver.verifySingleProcess: improve
    
1. Check `command.Run` error, print it out (as debug only).
    
2. Simplify `verifyOnlyOne()` return values (`bool` is enough).
    
3. Add more logging.