### PR TITLE
Cater for `trusted` case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ services:
 
 env:
   global:
-    - MAIN_BRANCH=private-master
+    - MAIN_BRANCH=v9.2.1
     - MQ_LTS_VERSION=9.2.0.1
     - TAGCACHE_FILE=tagcache
     - RELEASE=r1
@@ -40,7 +40,7 @@ go_import_path: "github.com/ibm-messaging/mq-container"
 jobs:
   include:
     - stage: basic-build
-      if: branch != private-master AND tag IS blank
+      if: branch != v9.2.1 AND tag IS blank
       name: "Basic AMD64 build"
       os: linux
       env:
@@ -50,12 +50,12 @@ jobs:
     # CD Build
 
     - stage: global-tag
-      if: branch = private-master AND type != pull_request OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 AND type != pull_request OR tag =~ ^release-candidate*
       name: "Generate Global Tag"
       os: linux
       script: bash -e travis-build-scripts/global-tag.sh
     - stage: build
-      if: branch = private-master OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 OR tag =~ ^release-candidate*
       name: "Multi-Arch AMD64 build"
       os: linux
       env:
@@ -63,7 +63,7 @@ jobs:
         - MQ_ARCHIVE_REPOSITORY=$MQ_921_ARCHIVE_REPOSITORY_AMD64
         - MQ_ARCHIVE_REPOSITORY_DEV=$MQ_921_ARCHIVE_REPOSITORY_DEV_AMD64
       script: bash -e travis-build-scripts/run.sh
-    # - if: branch = private-master OR tag =~ ^release-candidate*
+    # - if: branch = v9.2.1 OR tag =~ ^release-candidate*
     #   name: "Multi-Arch PPC64LE build"
     #   os: linux-ppc64le
     #   env:
@@ -73,7 +73,7 @@ jobs:
     #     - MQ_ARCHIVE_REPOSITORY_DEV=$MQ_921_ARCHIVE_REPOSITORY_DEV_PPC64LE
     #   script: bash -e travis-build-scripts/run.sh
     - stage: build
-      if: branch = private-master OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 OR tag =~ ^release-candidate*
       name: "Multi-Arch S390X build"
       os: linux-s390
       env:
@@ -83,7 +83,7 @@ jobs:
         - MQ_ARCHIVE_REPOSITORY_DEV=$MQ_921_ARCHIVE_REPOSITORY_DEV_S390X
       script: bash -e travis-build-scripts/run.sh
     - stage: push-manifest
-      if: branch = private-master AND type != pull_request OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 AND type != pull_request OR tag =~ ^release-candidate*
       name: "Push Manifest-list to registry"
       env:
         - PUSH_MANIFEST_ONLY=true
@@ -92,7 +92,7 @@ jobs:
       # LTS Build
 
     - stage: global-tag
-      if: branch = private-master AND type != pull_request OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 AND type != pull_request OR tag =~ ^release-candidate*
       name: "Generate Global Tag"
       os: linux
       env:
@@ -102,7 +102,7 @@ jobs:
         - RELEASE=$RELEASE_LTS
       script: bash -e travis-build-scripts/global-tag.sh
     - stage: build
-      if: branch = private-master OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 OR tag =~ ^release-candidate*
       name: "Multi-Arch AMD64 build"
       os: linux
       env:
@@ -113,7 +113,7 @@ jobs:
         - RELEASE=$RELEASE_LTS
       script: bash -e travis-build-scripts/run.sh
     - stage: build
-      if: branch = private-master OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 OR tag =~ ^release-candidate*
       name: "Multi-Arch S390X build"
       os: linux-s390
       env:
@@ -125,7 +125,7 @@ jobs:
         - RELEASE=$RELEASE_LTS
       script: bash -e travis-build-scripts/run.sh
     - stage: push-manifest
-      if: branch = private-master AND type != pull_request OR tag =~ ^release-candidate*
+      if: branch = v9.2.1 AND type != pull_request OR tag =~ ^release-candidate*
       name: "Push Manifest-list to registry"
       env:
         - LTS=true

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -171,8 +171,8 @@ func (ks *KeyStore) GetCertificateLabels() ([]string, error) {
 	var labels []string
 	for scanner.Scan() {
 		s := scanner.Text()
-		if strings.HasPrefix(s, "-") || strings.HasPrefix(s, "*-") {
-			s := strings.TrimLeft(s, "-*")
+		if strings.HasPrefix(s, "-") || strings.HasPrefix(s, "*-") || strings.HasPrefix(s, "!") {
+			s := strings.TrimLeft(s, "-*!")
 			labels = append(labels, strings.TrimSpace(s))
 		}
 	}


### PR DESCRIPTION
I've noticed whilst running tests with mTLS certificates that without this correction the code wouldn't be able to correctly initialize the CMS keystore when using an mTLS Server certificate.