### PR TITLE
fix: count instances of runmqdevserver correctly on M1 macs

### DIFF
--- a/cmd/runmqserver/process.go
+++ b/cmd/runmqserver/process.go
@@ -44,12 +44,22 @@ func verifySingleProcess() error {
 func verifyOnlyOne(programName string) (int, error) {
 	// #nosec G104
 	out, _, _ := command.Run("ps", "-e", "--format", "cmd")
-	//if this goes wrong then assume we are the only one
-	numOfProg := strings.Count(out, programName)
+	lines := strings.Split(out, "\n")
+	numOfProg := countLinesWith(lines, programName)
 	if numOfProg != 1 {
 		return numOfProg, fmt.Errorf("Expected there to be only 1 instance of %s but found %d", programName, numOfProg)
 	}
 	return numOfProg, nil
+}
+
+func countLinesWith(lines []string, pattern string) int {
+	var occurrences int
+	for i := range lines {
+		if strings.Contains(lines[i], pattern) {
+			occurrences += 1
+		}
+	}
+	return occurrences
 }
 
 // Determines the name of the currently running executable.

--- a/cmd/runmqserver/process_test.go
+++ b/cmd/runmqserver/process_test.go
@@ -1,0 +1,29 @@
+/*
+© Copyright IBM Corporation 2017
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE_2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import "testing"
+
+func TestCountLinesWith(t *testing.T) {
+	lines := []string{
+		"/usr/bin/qemu-x86_x64 /usr/local/bin/runmqdevserver runmqdevserver",
+		"date -u",
+	}
+	got := countLinesWith(lines, "runmqdevserver")
+	if got != 1 {
+		t.Fatalf("got %d occurances", got)
+	}
+}


### PR DESCRIPTION
With emulation runmqdevserver appears multiple times in a single line of `ps` output, so we need to count the number of lines with runmqdevserver instead.

Thanks to @master131 for finding this fix. 

Issue: https://github.com/ibm-messaging/mq-container/issues/476