### PR TITLE
Add MQ_QMGR_PRIMARY_LOGFILES, MQ_QMGR_SECONDARY_LOGFILES env variables for configuring logfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## XX (2025-XX)
+* New environment variables: MQ_QMGR_PRIMARY_LOGFILES, MQ_QMGR_SECONDARY_LOGFILES. These are meant to be set the number of logfiles when the default ones are not enough.
+
 ## 9.4.2.0 (2025-02)
 
 * Updated to MQ version 9.4.2.0

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Note that in order to use the image, it is necessary to accept the terms of the 
 - **LANG** - Set this to the language you would like the license to be printed in.
 - **MQ_QMGR_NAME** - Set this to the name you want your Queue Manager to be created with.
 - **MQ_QMGR_LOG_FILE_PAGES** - Set this to control the value for LogFilePages passed to the "crtmqm" command.  Cannot be changed after queue manager creation.
+- **MQ_QMGR_PRIMARY_LOGFILES** - Set this to control the value for LogPrimaryFiles passed to the "crtmqm" command. Cannot be changed after queue manager creation.
+- **MQ_QMGR_SECONDARY_LOGFILES** - Set this to control the value for LogSecondaryFiles passed to the "crtmqm" command. Cannot be changed after queue manager creation.
 - **MQ_LOGGING_CONSOLE_SOURCE** - Specifies a comma-separated list of sources for logs which are mirrored to the container's stdout. The valid values are "qmgr", "web" and "mqsc". Defaults to "qmgr,web". 
 - **MQ_LOGGING_CONSOLE_FORMAT** - Changes the format of the logs which are printed on the container's stdout.  Set to "json" to use JSON format (JSON object per line); set to "basic" to use a simple human-readable format.  Defaults to "basic".
 - **MQ_LOGGING_CONSOLE_EXCLUDE_ID** - Excludes log messages with the specified ID.  The log messages still appear in the log file on disk, but are excluded from the container's stdout.  Defaults to "AMQ5041I,AMQ5052I,AMQ5051I,AMQ5037I,AMQ5975I".

--- a/cmd/runmqserver/qmgr_test.go
+++ b/cmd/runmqserver/qmgr_test.go
@@ -208,7 +208,7 @@ func Test_validateSecondaryLogFileSetting(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			validate := validatePrimaryLogFileSetting(iniFileBytes, tt.args.primaryLogFilesValue)
+			validate := validateSecondaryLogFileSetting(iniFileBytes, tt.args.secondaryLogFilesValue)
 			if validate != tt.args.isValid {
 				t.Fatalf("Expected ini file validation output to be %v got %v", tt.args.isValid, validate)
 			}

--- a/cmd/runmqserver/qmgr_test.go
+++ b/cmd/runmqserver/qmgr_test.go
@@ -86,6 +86,136 @@ func Test_validateLogFilePageSetting(t *testing.T) {
 	}
 }
 
+func Test_validatePrimaryLogFileSetting(t *testing.T) {
+	type args struct {
+		iniFilePath            string
+		isValid                bool
+		primaryLogFilesValue   string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "TestPrimaryLogFile1",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogPrimaryFiles_1.ini",
+				isValid:           true,
+				primaryLogFilesValue: "3",
+			},
+		},
+		{
+			name: "TestPrimaryLogFile2",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogPrimaryFiles_2.ini",
+				isValid:           true,
+				primaryLogFilesValue: "3",
+			},
+		},
+		{
+			name: "TestPrimaryLogFile3",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogPrimaryFiles_3.ini",
+				isValid:           false,
+				primaryLogFilesValue: "10",
+			},
+		},
+		{
+			name: "TestPrimaryLogFile4",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogPrimaryFiles_4.ini",
+				isValid:           false,
+				primaryLogFilesValue: "3",
+			},
+		},
+		{
+			name: "TestPrimaryLogFile5",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogPrimaryFiles_5.ini",
+				isValid:           false,
+				primaryLogFilesValue: "1235",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iniFileBytes, err := os.ReadFile(tt.args.iniFilePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			validate := validatePrimaryLogFileSetting(iniFileBytes, tt.args.primaryLogFilesValue)
+			if validate != tt.args.isValid {
+				t.Fatalf("Expected ini file validation output to be %v got %v", tt.args.isValid, validate)
+			}
+		})
+	}
+}
+
+func Test_validateSecondaryLogFileSetting(t *testing.T) {
+	type args struct {
+		iniFilePath            string
+		isValid                bool
+		secondaryLogFilesValue string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "TestSecondaryLogFile1",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogSecondaryFiles_1.ini",
+				isValid:           true,
+				secondaryLogFilesValue: "2",
+			},
+		},
+		{
+			name: "TestSecondaryLogFile2",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogSecondaryFiles_2.ini",
+				isValid:           true,
+				secondaryLogFilesValue: "2",
+			},
+		},
+		{
+			name: "TestSecondaryLogFile3",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogSecondaryFiles_3.ini",
+				isValid:           false,
+				secondaryLogFilesValue: "10",
+			},
+		},
+		{
+			name: "TestSecondaryLogFile4",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogSecondaryFiles_4.ini",
+				isValid:           false,
+				secondaryLogFilesValue: "2",
+			},
+		},
+		{
+			name: "TestSecondaryLogFile5",
+			args: args{
+				iniFilePath:       "./test-files/testvalidateLogSecondaryFiles_5.ini",
+				isValid:           false,
+				secondaryLogFilesValue: "1235",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iniFileBytes, err := os.ReadFile(tt.args.iniFilePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			validate := validatePrimaryLogFileSetting(iniFileBytes, tt.args.primaryLogFilesValue)
+			if validate != tt.args.isValid {
+				t.Fatalf("Expected ini file validation output to be %v got %v", tt.args.isValid, validate)
+			}
+		})
+	}
+}
+
 // Unit test for special character in queue manager names
 func Test_SpecialCharInQMNameReplacements(t *testing.T) {
 	type qmNames struct {

--- a/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_1.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_1.ini
@@ -1,0 +1,9 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+   LogPrimaryFiles=3
+   LogSecondaryFiles=2
+   LogFilePages=1235
+   LogBufferPages=0
+   LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_2.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_2.ini
@@ -1,0 +1,9 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+   Log:
+         LogPrimaryFiles=3
+            LogSecondaryFiles=2
+          LogFilePages=2224
+            LogBufferPages=0
+          LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_3.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_3.ini
@@ -1,0 +1,9 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+        LogPrimaryFiles=3
+   LogSecondaryFiles=2
+   LogFilePages=6002
+   LogBufferPages=0
+   LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_4.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_4.ini
@@ -1,0 +1,7 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+   LogSecondaryFiles=2
+   LogBufferPages=0
+   LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_5.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogPrimaryFiles_5.ini
@@ -1,0 +1,7 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+   LogSecondaryFiles=2
+   LogBufferPages=3
+   LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_1.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_1.ini
@@ -1,0 +1,9 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+   LogPrimaryFiles=3
+   LogSecondaryFiles=2
+   LogFilePages=1235
+   LogBufferPages=0
+   LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_2.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_2.ini
@@ -1,0 +1,9 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+   Log:
+         LogPrimaryFiles=3
+            LogSecondaryFiles=2
+          LogFilePages=2224
+            LogBufferPages=0
+          LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_3.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_3.ini
@@ -1,0 +1,9 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+        LogPrimaryFiles=3
+   LogSecondaryFiles=2
+   LogFilePages=6002
+   LogBufferPages=0
+   LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_4.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_4.ini
@@ -1,0 +1,6 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+   LogBufferPages=0
+   LogWriteIntegrity=TripleWrite

--- a/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_5.ini
+++ b/cmd/runmqserver/test-files/testvalidateLogSecondaryFiles_5.ini
@@ -1,0 +1,6 @@
+ExitPath:
+   ExitsDefaultPath=/mnt/mqm/data/exits
+   ExitsDefaultPath64=/mnt/mqm/data/exits64
+Log:
+   LogBufferPages=12345
+   LogWriteIntegrity=TripleWrite

--- a/test/container/docker_api_test.go
+++ b/test/container/docker_api_test.go
@@ -1428,7 +1428,7 @@ func TestCustomPrimaryLogFiles(t *testing.T) {
 	defer cleanContainer(t, cli, id, false)
 	waitForReady(t, cli, id)
 
-	testPrimaryLogFiles(t, cli, id, "qmlfp", "8192")
+	testPrimaryLogFiles(t, cli, id, "qmlfp", "16")
 }
 
 // TestCustomSecondaryLogFiles starts a qmgr with a custom number of LogSecondaryFiles set.
@@ -1444,7 +1444,7 @@ func TestCustomSecondaryLogFiles(t *testing.T) {
 	defer cleanContainer(t, cli, id, false)
 	waitForReady(t, cli, id)
 
-	testSecondaryLogFiles(t, cli, id, "qmlfp", "8192")
+	testSecondaryLogFiles(t, cli, id, "qmlfp", "8")
 }
 
 // TestLoggingConsoleSource tests default behavior which is

--- a/test/container/docker_api_test.go
+++ b/test/container/docker_api_test.go
@@ -108,6 +108,14 @@ func goldenPath(t *testing.T, metrics bool) {
 	t.Run("Validate Default LogFilePages", func(t *testing.T) {
 		testLogFilePages(t, cli, id, "qm1", "4096")
 	})
+
+	t.Run("Validate Default LogPrimaryFiles", func(t *testing.T) {
+		testPrimaryLogFiles(t, cli, id, "qm1", "3")
+	})
+
+	t.Run("Validate Default LogSecondaryFiles", func(t *testing.T) {
+		testSecondaryLogFiles(t, cli, id, "qm1", "2")
+	})
 	// Stop the container cleanly
 	stopContainer(t, cli, id)
 }
@@ -1405,6 +1413,38 @@ func TestCustomLogFilePages(t *testing.T) {
 	waitForReady(t, cli, id)
 
 	testLogFilePages(t, cli, id, "qmlfp", "8192")
+}
+
+// TestCustomPrimaryLogFiles starts a qmgr with a custom number of LogPrimaryFiles set.
+// Check that the number of LogPrimaryFiles matches.
+func TestCustomPrimaryLogFiles(t *testing.T) {
+	t.Parallel()
+	cli := ce.NewContainerClient(ce.WithTestCommandLogger(t))
+	containerConfig := ce.ContainerConfig{
+		Env: []string{"LICENSE=accept", "MQ_QMGR_PRIMARY_LOGFILES=16", "MQ_QMGR_NAME=qmlfp"},
+	}
+
+	id := runContainer(t, cli, &containerConfig)
+	defer cleanContainer(t, cli, id, false)
+	waitForReady(t, cli, id)
+
+	testPrimaryLogFiles(t, cli, id, "qmlfp", "8192")
+}
+
+// TestCustomSecondaryLogFiles starts a qmgr with a custom number of LogSecondaryFiles set.
+// Check that the number of LogSecondaryFiles matches.
+func TestCustomSecondaryLogFiles(t *testing.T) {
+	t.Parallel()
+	cli := ce.NewContainerClient(ce.WithTestCommandLogger(t))
+	containerConfig := ce.ContainerConfig{
+		Env: []string{"LICENSE=accept", "MQ_QMGR_SECONDARY_LOGFILES=8", "MQ_QMGR_NAME=qmlfp"},
+	}
+
+	id := runContainer(t, cli, &containerConfig)
+	defer cleanContainer(t, cli, id, false)
+	waitForReady(t, cli, id)
+
+	testSecondaryLogFiles(t, cli, id, "qmlfp", "8192")
 }
 
 // TestLoggingConsoleSource tests default behavior which is

--- a/test/container/docker_api_test_util.go
+++ b/test/container/docker_api_test_util.go
@@ -974,6 +974,26 @@ func testLogFilePages(t *testing.T, cli ce.ContainerInterface, id string, qmName
 	}
 }
 
+// testPrimaryLogFiles validates that the specified number of LogPrimaryFiles is present in the qm.ini file.
+func testPrimaryLogFiles(t *testing.T, cli ce.ContainerInterface, id string, qmName string, expectedPrimaryLogFiles string) {
+	catIniFileCommand := fmt.Sprintf("cat /var/mqm/qmgrs/" + qmName + "/qm.ini")
+	_, iniContent := execContainer(t, cli, id, "", []string{"bash", "-c", catIniFileCommand})
+
+	if !strings.Contains(iniContent, "LogPrimaryFiles="+expectedPrimaryLogFiles) {
+		t.Errorf("Expected qm.ini to contain LogPrimaryFiles="+expectedPrimaryLogFiles+"; got qm.ini \"%v\"", iniContent)
+	}
+}
+
+// testSecondaryLogFiles validates that the specified number of LogSecondaryFiles is present in the qm.ini file.
+func testSecondaryLogFiles(t *testing.T, cli ce.ContainerInterface, id string, qmName string, expectedSecondaryLogFiles string) {
+	catIniFileCommand := fmt.Sprintf("cat /var/mqm/qmgrs/" + qmName + "/qm.ini")
+	_, iniContent := execContainer(t, cli, id, "", []string{"bash", "-c", catIniFileCommand})
+
+	if !strings.Contains(iniContent, "LogSecondaryFiles="+expectedSecondaryLogFiles) {
+		t.Errorf("Expected qm.ini to contain LogSecondaryFiles="+expectedSecondaryLogFiles+"; got qm.ini \"%v\"", iniContent)
+	}
+}
+
 // waitForMessageInLog will check for a particular message with wait
 func waitForMessageInLog(t *testing.T, cli ce.ContainerInterface, id string, expectedMessageId string) (string, error) {
 	var jsonLogs string


### PR DESCRIPTION
This pull request is about to introduce two new environment variables:

- MQ_QMGR_PRIMARY_LOGFILES - this is to configure the total count of primary logfiles used by the queue manager
- MQ_QMGR_SECONDARY_LOGFILES - this is to configure the total count of secondary logfiles used by the queue manager

With these two variables, you can configure the amount of log files to be created when initializing the container. The behaviour of these new variables (checks, scope, tests) are the same as the MQ_QMGR_LOG_FILE_PAGES parameter. A sample invocation is demonstrated below:

```
docker run  \
--env LICENSE=accept \
--env MQ_QMGR_NAME=QM1 \
--env MQ_QMGR_PRIMARY_LOGFILES=64 \
--env MQ_QMGR_SECONDARY_LOGFILES=32 \
--publish 1414:1414 \
--publish 9443:9443 \
--detach \
icr.io/ibm-messaging/mq
```

The reason behind this pull request is that the default values (primary: 3, secondary: 2) are often not ideal for a dev or prod environment.

The accompanying tests (unit and docker, similar to the LogFilePages ones) are also included in the pull request.